### PR TITLE
Use proper related query name for user devices in form

### DIFF
--- a/firebase_push/admin.py
+++ b/firebase_push/admin.py
@@ -82,7 +82,10 @@ class PushNotificationForm(forms.Form):
     link = forms.CharField(max_length=1024, label="Link", required=False)
 
     user = forms.ModelChoiceField(
-        UserModel.objects.annotate(device_count=Count("fcmdevice")).filter(device_count__gt=0), empty_label="User"
+        UserModel.objects.annotate(device_count=Count(FCMDevice._meta.get_field("user").related_query_name())).filter(
+            device_count__gt=0
+        ),
+        empty_label="User",
     )
     topic = forms.ModelChoiceField(FCMTopic.objects.all(), required=False)
 


### PR DESCRIPTION
Fixes an exception if the device model is not named `FCMDevice`