### PR TITLE
Allow overriding credentials file via setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ service account JSON file:
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json
 ```
 
+Alternatively you can use the django setting `FCM_CREDENTIALS_FILE` to provide the path.
+
 #### To generate a private key file for your service account:
 
 1. In the Firebase console, open **Settings** > [Service Accounts](https://console.firebase.google.com/project/_/settings/serviceaccounts/adminsdk).

--- a/firebase_push/tasks.py
+++ b/firebase_push/tasks.py
@@ -2,6 +2,8 @@ from traceback import format_exception
 
 import firebase_admin
 from celery import shared_task
+from django.conf import settings
+from firebase_admin import credentials
 from requests import HTTPError, Timeout
 
 from firebase_push.models import FCMHistoryBase
@@ -11,7 +13,14 @@ from firebase_push.utils import get_device_model
 FCMDevice = get_device_model()
 
 FCM_RETRY_EXCEPTIONS = (HTTPError, Timeout)
-firebase = firebase_admin.initialize_app()
+
+
+if credentials_file := getattr(settings, "FCM_CREDENTIALS_FILE", None):
+    credential = credentials.Certificate(credentials_file)
+else:
+    credential = None
+
+firebase = firebase_admin.initialize_app(credential=credential)
 
 
 @shared_task(autoretry_for=FCM_RETRY_EXCEPTIONS, retry_backoff=True)


### PR DESCRIPTION
Introduces the new `FCM_CREDENTIALS_FILE` setting. Can be used to provide/override the credentials file used by the lib.